### PR TITLE
feat: add 16 adaptive-shield-matrix icons

### DIFF
--- a/adaptive-shield-matrix/area-enter.svg
+++ b/adaptive-shield-matrix/area-enter.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <g stroke-opacity=".98" stroke="#000">
+    <path d="M30 57.56h40l20 30H10z" fill="none" stroke-width="7.76" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M50 67.56l-17.32-30h34.64zm-7.5-55h15v20h-15z" fill-rule="evenodd" stroke-width="8" stroke-linecap="square"/>
+  </g>
+</svg>

--- a/adaptive-shield-matrix/area-exit.svg
+++ b/adaptive-shield-matrix/area-exit.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <g stroke-opacity=".98" stroke="#000">
+    <path d="M30 59.56h40l20 30H10z" fill="none" stroke-width="7.76" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M50 14.56l17.32 30H32.68z" fill-opacity=".99" fill-rule="evenodd" stroke-width="8" stroke-linecap="square"/>
+    <path fill-rule="evenodd" stroke-width="8" stroke-linecap="square" d="M57.5 69.56h-15v-20h15z"/>
+  </g>
+</svg>

--- a/adaptive-shield-matrix/bottom-up.svg
+++ b/adaptive-shield-matrix/bottom-up.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <g transform="translate(-5 -922.05)" fill-rule="evenodd">
+    <circle cx="55" cy="940.48" r="13.42" paint-order="fill markers stroke"/>
+    <circle r="13.42" cy="1003.61" cx="20" paint-order="fill markers stroke"/>
+    <circle cx="55" cy="1003.61" r="13.42" paint-order="fill markers stroke"/>
+    <circle r="13.42" cy="1003.61" cx="90" paint-order="fill markers stroke"/>
+    <path d="M55 962.54v25.04" stroke="#000" stroke-width="5"/>
+    <path d="M46.25 967.61l6-2h5l7 2-9-9z"/>
+    <path d="M38.38 962.7L25.86 984.4" stroke="#000" stroke-width="5"/>
+    <path d="M43.42 971.47l-4.2-4.73-4.32-2.5-7.07-1.77 12.3-3.3z"/>
+    <g>
+      <path d="M71.62 962.7l12.52 21.69" stroke="#000" stroke-width="5"/>
+      <path d="M66.58 971.47l4.2-4.73 4.32-2.5 7.07-1.77-12.3-3.3z"/>
+    </g>
+  </g>
+</svg>

--- a/adaptive-shield-matrix/order-move.svg
+++ b/adaptive-shield-matrix/order-move.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <path d="M66.25 17.5V35h-25v30h25v17.5l30-32.5zM3.75 35v30h3V35zm7.5 0v30h5V35zm10 0v30h15V35z" fill-rule="evenodd"/>
+</svg>

--- a/adaptive-shield-matrix/select-all.svg
+++ b/adaptive-shield-matrix/select-all.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <path fill="none" stroke="#000" stroke-width="7" stroke-linecap="round" stroke-dashoffset="30" paint-order="fill markers stroke" d="M4.65 4.65h60v60h-60z"/>
+  <path d="M68.65 68.65L79.26 95.3l5.7-5.7 9.24 9.25 4.65-4.65-9.25-9.25 5.7-5.69z" fill-rule="evenodd"/>
+  <path fill-rule="evenodd" paint-order="fill markers stroke" d="M14.65 14.65h17v17h-17zm23 0h17v17h-17zm-23 23h17v17h-17zm23 0h17v17h-17z"/>
+</svg>

--- a/adaptive-shield-matrix/select-asleep.svg
+++ b/adaptive-shield-matrix/select-asleep.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <g transform="translate(39.65 -973.96)">
+    <path fill="none" stroke="#000" stroke-width="7" stroke-linecap="round" stroke-dashoffset="30" paint-order="fill markers stroke" d="M-35 978.61h60v60h-60z"/>
+    <path d="M29 1042.61l10.61 26.65 5.69-5.7 9.24 9.25 4.66-4.65-9.25-9.25 5.7-5.69z" fill-rule="evenodd"/>
+    <path d="M-27.78 989.03h19.17l-12.78 19.17h19.17" fill="none" stroke="#000" stroke-width="5.11"/>
+    <ellipse cx="-1" cy="1017.61" rx="6.84" ry="4.56" fill-opacity=".98" fill-rule="evenodd" paint-order="fill markers stroke"/>
+    <ellipse ry="3.07" rx="4.61" cy="1022.61" cx="11" fill-opacity=".98" fill-rule="evenodd" paint-order="fill markers stroke"/>
+    <ellipse cx="15" cy="1029.61" rx="2.91" ry="2.77" fill-opacity=".98" fill-rule="evenodd" paint-order="fill markers stroke"/>
+    <path d="M1.88 995.54l13.36 3.58-12.48 10.98 13.36 3.58" fill="none" stroke="#000" stroke-width="3.69"/>
+    <path d="M-25.89 1019.04l11.1-2.97-4.42 13.08 11.1-2.97" fill="none" stroke="#000" stroke-width="3.06"/>
+  </g>
+</svg>

--- a/adaptive-shield-matrix/select-best.svg
+++ b/adaptive-shield-matrix/select-best.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <path fill="none" stroke="#000" stroke-width="7" stroke-linecap="round" stroke-dashoffset="30" paint-order="fill markers stroke" d="M4.65 4.65h60v60h-60z"/>
+  <path d="M68.65 68.65L79.26 95.3l5.7-5.7 9.24 9.25 4.65-4.65-9.25-9.25 5.7-5.69z" fill-rule="evenodd"/>
+  <path d="M47.08 52l-12.4-8.57-12.34 8.65 4.32-14.44-12.04-9.07 15.07-.35 4.9-14.25 5 14.22 15.06.26-11.98 9.14z" fill-rule="evenodd" paint-order="fill markers stroke"/>
+</svg>

--- a/adaptive-shield-matrix/select-by-group.svg
+++ b/adaptive-shield-matrix/select-by-group.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <g transform="translate(19.65 -983.96)">
+    <path fill="none" stroke="#000" stroke-width="7" stroke-linecap="round" stroke-dashoffset="30" paint-order="fill markers stroke" d="M-15 988.61h60v60h-60z"/>
+    <path d="M49 1052.61l10.61 26.65 5.69-5.7 9.24 9.25 4.66-4.65-9.25-9.25 5.7-5.69z" fill-rule="evenodd"/>
+    <circle cx="8" cy="1011.61" fill-rule="evenodd" paint-order="fill markers stroke" r="15.37"/>
+    <circle cx="26.4" cy="1031.09" r="8.54" fill-rule="evenodd" paint-order="fill markers stroke"/>
+  </g>
+</svg>

--- a/adaptive-shield-matrix/select-by-type.svg
+++ b/adaptive-shield-matrix/select-by-type.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <g transform="translate(14.65 -958.96)">
+    <path fill="none" stroke="#000" stroke-width="7" stroke-linecap="round" stroke-dashoffset="30" paint-order="fill markers stroke" d="M-10 963.61h60v60h-60z"/>
+    <path d="M54 1027.61l10.61 26.65 5.69-5.7 9.24 9.25 4.66-4.65-9.25-9.25 5.7-5.69z" fill-rule="evenodd"/>
+    <circle r="9.71" cy="980.61" cx="8" fill-rule="evenodd" paint-order="fill markers stroke"/>
+    <path d="M-1.9 1016.33l43.8-45.43" fill="none" stroke="#000" stroke-width="4"/>
+    <path fill-rule="evenodd" paint-order="fill markers stroke" d="M23.5 998.72h17v15.79h-17z"/>
+  </g>
+</svg>

--- a/adaptive-shield-matrix/select-half.svg
+++ b/adaptive-shield-matrix/select-half.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <path fill="none" stroke="#000" stroke-width="7" stroke-linecap="round" stroke-dashoffset="30" paint-order="fill markers stroke" d="M4.65 4.65h60v60h-60z"/>
+  <path d="M68.65 68.65L79.26 95.3l5.7-5.7 9.24 9.25 4.65-4.65-9.25-9.25 5.7-5.69z" fill-rule="evenodd"/>
+  <path fill-rule="evenodd" paint-order="fill markers stroke" d="M14.65 14.65h17v17h-17zm23 0h17v17h-17z"/>
+</svg>

--- a/adaptive-shield-matrix/select-none.svg
+++ b/adaptive-shield-matrix/select-none.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <path fill="none" stroke="#000" stroke-width="7" stroke-linecap="round" stroke-dashoffset="30" paint-order="fill markers stroke" d="M4.65 4.65h60v60h-60z"/>
+  <path d="M68.65 68.65L79.26 95.3l5.7-5.7 9.24 9.25 4.65-4.65-9.25-9.25 5.7-5.69z" fill-rule="evenodd"/>
+</svg>

--- a/adaptive-shield-matrix/select-one.svg
+++ b/adaptive-shield-matrix/select-one.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <path fill="none" stroke="#000" stroke-width="7" stroke-linecap="round" stroke-dashoffset="30" paint-order="fill markers stroke" d="M4.65 4.65h60v60h-60z"/>
+  <path d="M68.65 68.65L79.26 95.3l5.7-5.7 9.24 9.25 4.65-4.65-9.25-9.25 5.7-5.69z" fill-rule="evenodd"/>
+  <path fill-rule="evenodd" paint-order="fill markers stroke" d="M14.65 14.65h17v17h-17z"/>
+</svg>

--- a/adaptive-shield-matrix/select-random.svg
+++ b/adaptive-shield-matrix/select-random.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <path fill="none" stroke="#000" stroke-width="7" stroke-linecap="round" stroke-dashoffset="30" paint-order="fill markers stroke" d="M4.65 4.65h60v60h-60z"/>
+  <path d="M68.65 68.65L79.26 95.3l5.7-5.7 9.24 9.25 4.65-4.65-9.25-9.25 5.7-5.69z" fill-rule="evenodd"/>
+  <text style="line-height:114.38965607px;-inkscape-font-specification:Bebas" x="1.72" y="1034.91" font-weight="400" font-size="61.01" font-family="Bebas" letter-spacing="0" word-spacing="0" stroke-width="4.58" transform="translate(14.65 -978.96)">
+    <tspan x="1.72" y="1034.91" style="-inkscape-font-specification:'Liberation Sans Bold'" font-weight="700" font-family="Liberation Sans">?</tspan>
+  </text>
+</svg>

--- a/adaptive-shield-matrix/stop.svg
+++ b/adaptive-shield-matrix/stop.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <path d="M95 50L75 10H25L5 50l20 40h50zM25 10l50 80" fill="none" stroke="#000" stroke-width="8"/>
+</svg>

--- a/adaptive-shield-matrix/top-down.svg
+++ b/adaptive-shield-matrix/top-down.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <g transform="translate(-5 -932.05)">
+    <circle r="13.42" cy="950.48" cx="55" fill-rule="evenodd" paint-order="fill markers stroke"/>
+    <circle cx="20" cy="1013.61" r="13.42" fill-rule="evenodd" paint-order="fill markers stroke"/>
+    <circle r="13.42" cy="1013.61" cx="55" fill-rule="evenodd" paint-order="fill markers stroke"/>
+    <circle cx="90" cy="1013.61" r="13.42" fill-rule="evenodd" paint-order="fill markers stroke"/>
+    <path d="M55 993.65V968.6" fill="none" stroke="#000" stroke-width="5"/>
+    <path d="M46.25 988.58l6 2h5l7-2-9 9z" fill-rule="evenodd"/>
+    <path d="M28.74 992.1l12.52-21.67" fill="none" stroke="#000" stroke-width="5"/>
+    <path d="M23.7 983.34l4.2 4.73 4.32 2.5 7.07 1.77-12.3 3.3z" fill-rule="evenodd"/>
+    <path d="M81.26 992.1l-12.52-21.67" fill="none" stroke="#000" stroke-width="5"/>
+    <path d="M86.3 983.34l-4.2 4.73-4.32 2.5-7.07 1.77 12.3 3.3z" fill-rule="evenodd"/>
+  </g>
+</svg>

--- a/adaptive-shield-matrix/transform.svg
+++ b/adaptive-shield-matrix/transform.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <path d="M61.6 50.91H34.08" fill="none" stroke="#000" stroke-width="6.86"/>
+  <path d="M54.65 38.9l2.75 8.24V54l-2.75 9.6L67 51.26zM70.44 38.4h25.1v25.1h-25.1zm-34.9 25H4.46L20 36.5z" fill-rule="evenodd"/>
+</svg>

--- a/license.txt
+++ b/license.txt
@@ -35,6 +35,7 @@ Each sub-folders in this archive correspond to a different contributor :
 - Starseeker
 - Pepijn Poolman
 - Pierre Leducq
+- adaptive-shield-matrix - CC0
 
 Please, include a mention "Icons made by {author}" in your derivative work.
 


### PR DESCRIPTION
My Icons have a size of 100 x 100 and are in black instead of white. 
I hope It's still okay?

I had problems resizing them to 512, because
1) existing icons have an unspecified whiteguard border on all sides (maybe add it to the style guide and/or CONTRIBUTING.md?)
2) because of the even number (512), I cannot center an icon, because it will either be 1 pixel to the right or 1 pixel to the left....
