### PR TITLE
Add alchemical planet symbols

### DIFF
--- a/seregacthtuf/alchemical-earth-symbol.svg
+++ b/seregacthtuf/alchemical-earth-symbol.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 512 512"
+   style="height: 512px; width: 512px;"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="earth.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:zoom="1.0675655"
+     inkscape:cx="249.16504"
+     inkscape:cy="295.53222"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     id="g4">
+    <path
+       d="m 256,27.917969 c -6.74327,0 -13.4034,0.353027 -20,0.929687 C 126.19884,38.446228 38.446228,126.19884 28.847656,236 c -0.57666,6.5966 -0.929687,13.25673 -0.929687,20 0,6.74327 0.353027,13.4034 0.929687,20 C 38.446228,385.80116 126.19884,473.55377 236,483.15234 c 6.5966,0.57666 13.25673,0.92969 20,0.92969 6.74327,0 13.4034,-0.35303 20,-0.92969 C 385.80116,473.55377 473.55377,385.80116 483.15234,276 c 0.57666,-6.5966 0.92969,-13.25673 0.92969,-20 0,-6.74327 -0.35303,-13.4034 -0.92969,-20 C 473.55377,126.19884 385.80116,38.446228 276,28.847656 269.4034,28.270996 262.74327,27.917969 256,27.917969 Z M 236,68.978516 V 236 H 68.978516 C 78.231679,147.91629 147.91629,78.231679 236,68.978516 Z m 40,0 C 364.08371,78.231679 433.76832,147.91629 443.02148,236 H 276 Z M 68.978516,276 H 236 V 443.02148 C 147.91629,433.76832 78.231679,364.08371 68.978516,276 Z M 276,276 H 443.02148 C 433.76832,364.08371 364.08371,433.76832 276,443.02148 Z"
+       style="fill:#ffffff;stroke-width:39.9999;stroke-linecap:square;stroke-miterlimit:10"
+       id="path10" />
+  </g>
+</svg>

--- a/seregacthtuf/alchemical-jupiter-symbol.svg
+++ b/seregacthtuf/alchemical-jupiter-symbol.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 512 512"
+   style="height: 512px; width: 512px;"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="jupiter.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:zoom="0.75488282"
+     inkscape:cx="366.28202"
+     inkscape:cy="386.15265"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     id="path1"
+     inkscape:label="g1">
+    <path
+       d="m 79.164062,25.008789 -17.025391,36.195313 18.097657,8.513671 c 61.149912,28.761811 97.117222,81.573377 97.160162,137.634767 -0.18895,54.7614 -34.71861,106.31404 -93.416022,135.38476 v 40 h 4.767578 4.46875 H 292.625 v 86.0625 18.19141 h 40 V 468.7998 382.7373 h 97.23633 20 v -40 h -20 -97.23633 v -85.40039 -18.1914 h -40 v 18.1914 85.40039 H 154.42578 c 39.29776,-35.85843 62.80894,-83.82529 62.97266,-135.29297 v -0.0371 -0.0371 C 217.36317,134.16257 170.22026,67.836498 97.261718,33.520508 Z"
+       style="height:512px;width:512px;stroke-linecap:square;stroke-miterlimit:10;fill:#ffffff"
+       id="path12" />
+  </g>
+</svg>

--- a/seregacthtuf/alchemical-mercury-symbol.svg
+++ b/seregacthtuf/alchemical-mercury-symbol.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 512 512"
+   style="height: 512px; width: 512px;"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="mercury.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:zoom="0.75488281"
+     inkscape:cx="335.81371"
+     inkscape:cy="338.46313"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g12" />
+  <g
+     id="g12"
+     inkscape:label="g1">
+    <path
+       id="path11"
+       style="fill:#ffffff;stroke-width:0.999994;stroke-linecap:square;stroke-miterlimit:10;paint-order:markers stroke fill"
+       d="m 161.00626,25.4375 v 19.355233 c -1.5e-4,30.774338 14.8501,58.248577 37.72757,75.638507 -22.87688,17.39002 -37.72757,44.86484 -37.72757,75.63851 0,45.60659 32.59901,83.984 75.6385,92.99017 v 2.57439 80.70793 h -68.49559 -7.14291 v 38.71046 h 7.14291 68.49559 v 56.28327 19.35524 h 38.71047 V 467.33597 411.0527 h 68.49559 7.14291 v -38.71046 h -7.14291 -68.49559 v -80.70793 -2.57439 c 43.03951,-9.00617 75.6385,-47.38358 75.6385,-92.99017 0,-30.77367 -14.85069,-58.24849 -37.72758,-75.63851 22.87749,-17.38993 37.72773,-44.864172 37.72758,-75.638507 V 25.4375 H 312.28327 V 44.792733 C 312.28342,76.106398 287.31366,101.07616 256,101.07601 224.68634,101.07616 199.71658,76.1064 199.71672,44.792733 V 25.4375 Z M 256,139.78647 c 31.31346,0 56.28327,24.96983 56.28327,56.28328 0,31.31345 -24.96981,56.28328 -56.28327,56.28328 -31.31346,0 -56.28328,-24.96983 -56.28328,-56.28328 0,-31.31345 24.96982,-56.28328 56.28328,-56.28328 z" />
+  </g>
+</svg>

--- a/seregacthtuf/alchemical-moon-symbol.svg
+++ b/seregacthtuf/alchemical-moon-symbol.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 512 512"
+   style="height: 512px; width: 512px;"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="moon.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <g
+     id="g4"
+     style="fill:#ffffff">
+    <path
+       style="fill:#ffffff;stroke-miterlimit:16"
+       d="m 445.92773,28.03125 -5.64881,0.252917 C 406.32117,29.804575 351.34363,35.263677 319.24524,46.340899 213.10421,82.970386 139.82017,162.59057 139.51562,255.93945 V 256 c 0,7.6e-4 -4e-4,0.0163 -0.001,0.0464 -0.72389,33.93234 19.92092,87.34128 40.55267,114.32743 31.78011,41.56811 80.36513,74.95324 138.98782,95.21988 32.19598,11.13057 87.30438,17.42471 121.31176,19.96045 l 5.55895,0.4145 -64.19922,-39.33008 C 309.13993,402.1702 276.82862,331.26851 276.58008,256 276.82895,180.73125 309.04462,109.67132 381.72852,65.361328 Z M 301.31836,93.730469 C 261.95407,139.81793 239.42411,196.46124 239.24414,255.94336 V 256 v 0.0566 c 0.17971,59.48166 22.70873,116.12548 62.07227,162.21289 C 224.55257,382.64365 177.09375,321.27245 176.85156,256 177.09387,190.72687 224.55309,129.35611 301.31836,93.730469 Z"
+       id="path3"
+       inkscape:path-effect="#path-effect4"
+       sodipodi:nodetypes="cccccccccscccccccccc"
+       transform="translate(-36.711926,-0.999955)" />
+  </g>
+  <defs
+     id="defs1">
+    <inkscape:path-effect
+       effect="fillet_chamfer"
+       id="path-effect4"
+       is_visible="true"
+       lpeversion="1"
+       nodesatellites_param="F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 | F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1"
+       radius="0"
+       unit="px"
+       method="auto"
+       mode="F"
+       chamfer_steps="1"
+       flexible="false"
+       use_knot_distance="true"
+       apply_no_radius="true"
+       apply_with_radius="true"
+       only_selected="false"
+       hide_knots="false" />
+  </defs>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:zoom="1.5097656"
+     inkscape:cx="295.74127"
+     inkscape:cy="273.22122"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+</svg>

--- a/seregacthtuf/alchemical-neptune-symbol.svg
+++ b/seregacthtuf/alchemical-neptune-symbol.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 512 512"
+   style="height: 512px; width: 512px;"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="neptune.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:zoom="1.0675655"
+     inkscape:cx="251.03846"
+     inkscape:cy="235.58273"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     id="g4"
+     transform="matrix(1,0,0,1.0757275,1.4996867e-6,-47.304248)"
+     style="stroke-width:0.964159">
+    <path
+       d="m 45.443358,71.700705 0.002,19.283825 c 2.53e-4,58.02916 24.231968,106.49122 62.892579,139.0084 34.23233,28.79257 79.17757,45.41509 128.37891,48.85139 v 87.56973 H 117.07226 97.789061 v 38.56583 H 117.07226 236.7168 v 67.94276 19.28201 h 38.5664 v -19.28201 -67.94276 h 119.64453 19.28321 V 366.41405 H 394.92773 275.2832 v -87.56973 c 49.202,-3.43635 94.14606,-20.0599 128.37891,-48.85321 38.66018,-32.51713 62.89232,-80.97783 62.89258,-139.00658 l 0.002,-19.283825 H 427.99023 V 90.98453 c -2e-4,47.60738 -18.58593,83.78221 -49.15234,109.49167 -26.48443,22.2761 -62.55617,36.33282 -103.55469,39.69516 V 91.40394 72.121931 H 236.7168 V 91.40394 240.17136 C 195.71819,236.80926 159.64685,222.75233 133.16211,200.4762 102.59534,174.7667 84.009971,138.59225 84.009764,90.98453 V 71.700705 Z"
+       style="fill:#ffffff;stroke-linecap:square;stroke-miterlimit:10"
+       id="path5" />
+  </g>
+</svg>

--- a/seregacthtuf/alchemical-saturn-symbol.svg
+++ b/seregacthtuf/alchemical-saturn-symbol.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 512 512"
+   style="height: 512px; width: 512px;"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="saturn.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <inkscape:path-effect
+       effect="fillet_chamfer"
+       id="path-effect12"
+       is_visible="true"
+       lpeversion="1"
+       nodesatellites_param="F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,13.416991,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1 @ F,0,0,1,0,0,0,1"
+       radius="0"
+       unit="px"
+       method="auto"
+       mode="F"
+       chamfer_steps="1"
+       flexible="false"
+       use_knot_distance="true"
+       apply_no_radius="true"
+       apply_with_radius="true"
+       only_selected="false"
+       hide_knots="false" />
+  </defs>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:zoom="0.5"
+     inkscape:cx="332"
+     inkscape:cy="227"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <path
+     d="m 235.53648,31.170898 -40,0.25 0.125,20 0.375,62.625002 h -69.93555 v 39.99999 h 70.18555 l 0.3125,49.4375 0.0352,51.60157 0.004,6.07422 h 39.85352 c 0.0321,-1.20076 0.05,-2.15393 0.14453,-3.5586 0.42057,-6.24887 1.52394,-14.2005 4.39844,-21.90234 5.95857,-15.9656 14.24042,-29.44922 48.04478,-29.44922 34.47188,0 44.29422,12.93505 50.83008,26.86914 1.99653,4.61664 3.56868,10.28416 4.5957,15.63672 1.39372,7.26365 1.00148,19.44728 -1.6543,26.31445 -0.38615,0.9985 -0.81214,2.0941 -1.27929,3.33594 -4.43231,11.78262 -13.39029,29.24557 -31.92188,50.03711 -50.84855,57.0496 -45.88376,122.24794 -39.85351,152.38672 l 2.87695,-0.0176 h 37.95703 c -4.29564,-13.76126 -18.63242,-72.45047 28.87891,-125.75586 21.70133,-24.34783 33.36749,-46.25887 39.50195,-62.56641 6.08766,-16.18311 6.78052,-28.56787 6.79102,-28.75781 0.0936,-1.39491 1.43245,-23.91526 -9.67774,-47.60156 -11.46393,-24.44089 -40.0168,-49.88084 -87.04492,-49.88084 -21.5249,0 -38.98755,5.9293 -52.62109,14.83984 l -0.17383,-27.04297 h 69.875 V 114.0459 h -70.125 l -0.375,-62.875002 z"
+     style="fill:#ffffff"
+     id="path12" />
+</svg>

--- a/seregacthtuf/alchemical-sun-symbol.svg
+++ b/seregacthtuf/alchemical-sun-symbol.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 512 512"
+   style="height: 512px; width: 512px;"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="sun.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:zoom="1.0675655"
+     inkscape:cx="249.63339"
+     inkscape:cy="295.53222"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     id="g4">
+    <path
+       id="path3"
+       style="fill:#ffffff;stroke-width:39.9999;stroke-linecap:square;stroke-miterlimit:10"
+       transform="scale(-1)"
+       d="m -213.51894,-256 c 0,23.46164 -19.01942,42.48106 -42.48106,42.48106 -23.46164,0 -42.48106,-19.01942 -42.48106,-42.48106 0,-23.46164 19.01942,-42.48106 42.48106,-42.48106 23.46164,0 42.48106,19.01942 42.48106,42.48106 z M -256,-27.917969 c 125.72901,0 228.082031,-102.353021 228.082031,-228.082031 0,-125.72901 -102.353021,-228.08203 -228.082031,-228.08203 -125.72901,0 -228.08203,102.35302 -228.08203,228.08203 0,125.72901 102.35302,228.082031 228.08203,228.082031 z m 0,-40 c -104.1114,0 -188.08203,-83.970631 -188.08203,-188.082031 0,-104.1114 83.97063,-188.08203 188.08203,-188.08203 104.1114,0 188.082031,83.97063 188.082031,188.08203 0,104.1114 -83.970631,188.082031 -188.082031,188.082031 z"
+       sodipodi:nodetypes="sssssssssssssss" />
+  </g>
+</svg>

--- a/seregacthtuf/alchemical-uranus-symbol.svg
+++ b/seregacthtuf/alchemical-uranus-symbol.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 512 512"
+   style="height: 512px; width: 512px;"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="uranus.svg"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:zoom="0.75488282"
+     inkscape:cx="156.97801"
+     inkscape:cy="349.0608"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     id="g13"
+     transform="translate(0,5.017578)">
+    <path
+       d="m 256,324.21875 c -19.85841,0 -35.95703,16.09667 -35.95703,35.95508 0,19.85841 16.09862,35.95703 35.95703,35.95703 19.85841,0 35.95703,-16.09862 35.95703,-35.95703 0,-19.85841 -16.09862,-35.95508 -35.95703,-35.95508 z"
+       style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;fill:#ffffff;stroke-linecap:square;stroke-miterlimit:10;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+       id="path13" />
+    <path
+       d="M 256,17.615234 227.71484,45.898437 113.85742,159.75586 99.714844,173.89844 128,202.18359 142.14258,188.04102 236,94.183594 V 237.64062 c -58.90428,9.62808 -104.17578,60.99972 -104.17578,122.53516 0,68.34318 55.8326,124.17383 124.17578,124.17383 68.34318,0 124.17578,-55.83065 124.17578,-124.17383 0,-61.53544 -45.2715,-112.90708 -104.17578,-122.53516 V 94.183594 L 369.85742,188.04102 384,202.18359 412.28516,173.89844 398.14258,159.75586 276,37.613281 270.14258,31.755859 Z M 256,276 c 46.72558,0 84.17578,37.4502 84.17578,84.17578 0,46.72558 -37.4502,84.17383 -84.17578,84.17383 -46.72558,0 -84.17578,-37.44825 -84.17578,-84.17383 C 171.82422,313.4502 209.27442,276 256,276 Z"
+       style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;fill:#ffffff;stroke-linecap:square;stroke-miterlimit:10;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+       id="path12" />
+  </g>
+</svg>


### PR DESCRIPTION
Alchemical symbols for: sun, mercury, earth, moon, jupiter, saturn, uranus and neptune.
closes #1125 

Author: me
Descriptions:
- Sun: The alchemical symbol for gold, representing perfection, spirit, and the life force.
- Moon: The alchemical symbol for silver, representing intuition, cycles, and the soul.
- Mercury: The alchemical symbol for quicksilver (mercury), representing fluidity, transformation, and communication between elements.
- Earth: Primarily the astronomical symbol for the planet, later used in alchemy to also represent the metal antimony.
- Jupiter: The alchemical symbol for tin, representing expansion, wisdom, and the process of fermentation.
- Saturn: The alchemical symbol for lead, representing time, limitation, and the necessary stage of purification.
- Uranus: A modern symbol for the planet (discovered in 1781), associated in later esoteric thought with sudden insight, innovation, and breaking convention.
- Neptune: A modern symbol for the planet (discovered in 1846), associated in later esoteric thought with the subconscious, dreams, and the dissolution of boundaries.

Preview:
<img width="619" height="353" alt="image" src="https://github.com/user-attachments/assets/09663938-11c1-4c22-b904-903a0d8caae5" />